### PR TITLE
Mention extension's `Info.plist` and `User Script Sandboxing` in the tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ On development build `eas build` should take care of it.
 ### Android
 
 1. Add camera and microphone permissions to your `AndroidManifest.xml`.
-2. For android 14+ add following code in your `AndroidManifest.xml` in application section :
+2. For android 14+ add following code in your `AndroidManifest.xml` in application section:
 ```xml
 <service
   android:name=".YourServiceName"
   android:foregroundServiceType="mediaProjection"
   android:exported="false">
+</service>
 ```
 3. Rebuild the app. That's it!
 


### PR DESCRIPTION
## Description
Mention extension's `Info.plist` and `User Script Sandboxing` in the tutorial

## Motivation and Context
Seems like these two are missing from the tutorial and are needed to set up the SDK properly.
